### PR TITLE
web: respect channel width

### DIFF
--- a/web/src/ble.ts
+++ b/web/src/ble.ts
@@ -85,6 +85,9 @@ export class BLEDevice implements Device {
       valid: () => {
         return this.dev.gatt.connected && !closed;
       },
+      width() {
+        return 10;
+      },
       subscribe: (q: Queue) => {
         subscribers.add(q);
       },

--- a/web/src/device.ts
+++ b/web/src/device.ts
@@ -62,6 +62,7 @@ export class QueueList {
 export interface Channel {
   name(): string;
   valid(): boolean;
+  width(): number;
   subscribe(queue: Queue): void;
   unsubscribe(queue: Queue): void;
   write(data: Uint8Array): Promise<void>;

--- a/web/src/fs.ts
+++ b/web/src/fs.ts
@@ -178,6 +178,9 @@ export async function writeFile(
   let cmd = pack("oos", 2, (1 << 0) | (1 << 2), file);
   await send(session, cmd, true);
 
+  // get width
+  const width = session.channel().width();
+
   // get MTU
   let mtu = await session.getMTU();
 
@@ -193,7 +196,7 @@ export async function writeFile(
     let chunkData = data.slice(offset, offset + chunkSize);
 
     // determine mode
-    let acked = num % 10 === 0;
+    let acked = num % width === 0;
 
     // prepare "write" command (acked or silent & sequential)
     cmd = pack("ooib", 4, acked ? 0 : (1 << 0) | (1 << 1), offset, chunkData);

--- a/web/src/http.ts
+++ b/web/src/http.ts
@@ -47,6 +47,9 @@ export class HTTPDevice implements Device {
       valid() {
         return true;
       },
+      width() {
+        return 10;
+      },
       subscribe: (q: Queue) => {
         subscribers.add(q);
       },

--- a/web/src/relay.ts
+++ b/web/src/relay.ts
@@ -115,6 +115,9 @@ export class RelayDevice implements Device {
       valid() {
         return true;
       },
+      width() {
+        return 10;
+      },
       subscribe: (q: Queue) => {
         subscribers.add(q);
       },

--- a/web/src/serial.ts
+++ b/web/src/serial.ts
@@ -109,6 +109,9 @@ export class SerialDevice implements Device {
       valid() {
         return true;
       },
+      width() {
+        return 10;
+      },
       subscribe: (q: Queue) => {
         subscribers.add(q);
       },

--- a/web/src/session.ts
+++ b/web/src/session.ts
@@ -43,6 +43,10 @@ export class Session {
     this.qu = qu;
   }
 
+  channel(): Channel {
+    return this.ch;
+  }
+
   async ping(timeout: number = 5000) {
     // write command
     await write(this.ch, new Message(this.id, 0xfe, null));

--- a/web/src/update.ts
+++ b/web/src/update.ts
@@ -21,6 +21,9 @@ export async function update(
     throw new Error("invalid message");
   }
 
+  // get width
+  const width = session.channel().width();
+
   // get MTU
   let mtu = await session.getMTU();
 
@@ -36,7 +39,7 @@ export async function update(
     let chunkData = data.slice(offset, offset + chunkSize);
 
     // determine acked
-    let acked = num % 10 == 0;
+    let acked = num % width === 0;
 
     // send "write" command
     cmd = pack("oob", 1, acked ? 1 : 0, chunkData);


### PR DESCRIPTION
## Summary
- add channel width accessors to web channel interface implementations
- expose session channel and use channel width when scheduling acks for fs/write and update flows

## Testing
- not run
